### PR TITLE
fix: unmarshall SQS event and process all records

### DIFF
--- a/app/cmd/portalrunid/main.go
+++ b/app/cmd/portalrunid/main.go
@@ -1,9 +1,13 @@
 package main
 
 import (
+	"encoding/json"
+	"fmt"
 	fmannotator "github.com/OrcaBus/service-fmannotator/app"
+	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-lambda-go/lambda"
 	"github.com/aws/aws-secretsmanager-caching-go/secretcache"
+	"log/slog"
 )
 
 var (
@@ -11,13 +15,30 @@ var (
 )
 
 // Handler for the portalRunId annotator function.
-func Handler(event fmannotator.Event) error {
+func Handler(event events.SQSEvent) error {
 	config, token, err := fmannotator.LoadCachedConfig(secretCache)
 	if err != nil {
 		return err
 	}
 
-	return fmannotator.PortalRunId(event, config, token)
+	for _, record := range event.Records {
+		body := record.Body
+		slog.Debug(fmt.Sprintf("processing record: %v", body))
+
+		var workflowRunEvent fmannotator.Event
+		err = json.Unmarshal([]byte(body), &workflowRunEvent)
+		if err != nil {
+			return err
+		}
+		slog.Debug(fmt.Sprintf("unmarshalled event: %v", workflowRunEvent))
+
+		err = fmannotator.PortalRunId(workflowRunEvent, config, token)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func main() {

--- a/app/event.go
+++ b/app/event.go
@@ -4,12 +4,12 @@ package fmannotator
 // Event The event type that the fmannotator can consume. This omits details that do not need to be deserialized
 // to maximise the flexibility.
 type Event struct {
-	Detail WorkflowRunStateChange `json:"detail,omitempty"`
+	Detail WorkflowRunStateChange `json:"detail"`
 }
 
 // WorkflowRunStateChange The workflow run state change type definition. The fmannotator only needs access to
 // the `PortalRunId` and `Status`.
 type WorkflowRunStateChange struct {
-	PortalRunId string `json:"portalRunId,omitempty"`
-	Status      string `json:"status,omitempty"`
+	PortalRunId string `json:"portalRunId"`
+	Status      string `json:"status"`
 }

--- a/app/handlers.go
+++ b/app/handlers.go
@@ -16,6 +16,7 @@ import (
 func PortalRunId(event Event, config *Config, token string) (err error) {
 	eventStatus := strings.ToUpper(event.Detail.Status)
 	if eventStatus != "SUCCEEDED" && eventStatus != "FAILED" && eventStatus != "ABORTED" {
+		slog.Debug(fmt.Sprintf("not running for event: %v", eventStatus))
 		return nil
 	}
 


### PR DESCRIPTION
Fixes issue introduced in #8

* #8 changed the event delivery to the Lambda from EventBridge -> Lambda to EventBridge -> SQS -> Lambda but didn't take into account the structural change in the event format. 
    * The SQS Lambda events are batched in an outer `Records` field which is different to how EventBridge handles events.

### Changes
* First unmarshals an `SQSEvent` and processes all `Records` individually in the `PortalRunId` to account for SQS events.
* Change the `Event` struct definition to fail if it can't unmarshal an event properly rather than just creating an empty representation.
